### PR TITLE
Fix gallery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     directory: "/docs"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "sphinx-gallery"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ sphinx==5.3.0
 sphinx-click==4.3.0
 sphinx-rtd-theme==1.1.1
 autodoc_pydantic==1.8.0
-sphinx-gallery==0.11.1
+sphinx-gallery==0.10.1
 nbsphinx==0.8.10
 ipykernel==6.17.1


### PR DESCRIPTION
sphinx-gallery > 1.10.1 has a compatibility issue with nbsphinx. Reverted the version and ignore the dependabot update.