### PR TITLE
Ignored CVE-2019-8341 for jinja2.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,13 @@ except ImportError:
 
 package = "laptrack"
 python_versions = ["3.12", "3.11", "3.10", "3.9", "3.8"]
-safety_ignore = [44717, 44715, 44716, 51457]  # ignore numpy 1.21 CVEs and py 1.11.0
+safety_ignore = [
+    44717,
+    44715,
+    44716,
+    51457,
+    70612,
+]  # ignore numpy 1.21 CVEs and py 1.11.0
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",


### PR DESCRIPTION
> In Jinja2, the from_string function is prone to Server Side Template Injection (SSTI) where it takes the "source" parameter as a template object, renders it, and then returns it. The attacker can exploit it with {{INJECTION COMMANDS}} in a URI.
NOTE: The maintainer and multiple third parties believe that this vulnerability isn't valid because users shouldn't use untrusted templates without sandboxing.

We are not using untrusted template and I believe we can safely ignore this.