### PR TITLE
Fix typo in gap closing docstring

### DIFF
--- a/src/laptrack/_tracking.py
+++ b/src/laptrack/_tracking.py
@@ -326,7 +326,7 @@ class LapTrack(BaseModel, extra="forbid"):
         Parameters
         ----------
         segments_df : pd.DataFrame
-            must have the columns "first_frame", "first_index", "first_crame_coords", "last_frame", "last_index", "last_frame_coords"
+            must have the columns "first_frame", "first_index", "first_frame_coords", "last_frame", "last_index", "last_frame_coords"
         force_end_nodes : list of int
             the indices of the segments_df that is forced to be end for future connection
         force_start_nodes : list of int


### PR DESCRIPTION
## Summary
- fix a typo in the `_get_gap_closing_matrix` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_687a2bb8f2e883228e97267884e8a48d