### PR TITLE
Deprecate the overwritten metric fields in OverLapTrack (#566)

### DIFF
--- a/src/laptrack/__main__.py
+++ b/src/laptrack/__main__.py
@@ -18,19 +18,14 @@ from tap import Tap
 
 from . import __version__
 from ._tracking import LapTrack
+from ._overlap_tracking import DEPRECATED_OVERLAP_FIELDS
 from ._overlap_tracking import OverLapTrack
 from ._tracking_result import TrackingResult
 
 #: The fields not exposed as command-line arguments.
 _EXCLUDED_FIELDS = {
     LapTrack: [],
-    OverLapTrack: [
-        # these are overwritten from *_metric_coefs in predict_overlap_dataframe
-        "metric",
-        "gap_closing_metric",
-        "splitting_metric",
-        "merging_metric",
-    ],
+    OverLapTrack: DEPRECATED_OVERLAP_FIELDS,
 }
 
 

--- a/src/laptrack/_overlap_tracking.py
+++ b/src/laptrack/_overlap_tracking.py
@@ -25,6 +25,15 @@ _ALIAS_FIELDS = {
     "merging_dist_metric_coefs": "merging_metric_coefs",
 }
 
+#: The parent-class fields that are overwritten internally from `*_metric_coefs`
+#: and thus have no effect when set by the user.
+DEPRECATED_OVERLAP_FIELDS = [
+    "metric",
+    "gap_closing_metric",
+    "splitting_metric",
+    "merging_metric",
+]
+
 
 class OverLapTrack(LapTrack):
     """Tracking by label overlaps."""
@@ -63,6 +72,22 @@ class OverLapTrack(LapTrack):
                         DeprecationWarning,
                     )
                     data[new_name] = data.pop(old_name)
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_overwritten_metric_fields(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            for name in DEPRECATED_OVERLAP_FIELDS:
+                if name in data:
+                    warnings.warn(
+                        f"Setting `{name}` has no effect in OverLapTrack, "
+                        f"since it is overwritten internally from the "
+                        f"corresponding `*_metric_coefs` parameter. "
+                        f"The given value is ignored.",
+                        DeprecationWarning,
+                    )
+                    data.pop(name)
         return data
 
     def predict_overlap_tracking_result(

--- a/tests/test_overlap_tracking.py
+++ b/tests/test_overlap_tracking.py
@@ -144,3 +144,15 @@ def test_overlap_tracking_error() -> None:
     with pytest.raises(AttributeError):
         olt.predict([np.array([1, 2, 3]), np.array([4, 5, 6])])
 """
+
+
+def test_overwritten_metric_fields_deprecated() -> None:
+    from laptrack import OverLapTrack
+
+    with pytest.warns(DeprecationWarning, match="has no effect in OverLapTrack"):
+        olt = OverLapTrack(metric="euclidean")
+    # the given value is ignored and the default is kept
+    assert olt.metric == "sqeuclidean"
+
+    with pytest.warns(DeprecationWarning, match="has no effect in OverLapTrack"):
+        OverLapTrack(splitting_metric="euclidean")


### PR DESCRIPTION
## Summary
Second half of #566 (the CLI arg generation for OverLapTrack is in the #528 CLI PR; this PR is stacked on that branch).

- Warn with `DeprecationWarning` and ignore the value when `metric`, `gap_closing_metric`, `splitting_metric` or `merging_metric` is passed to `OverLapTrack` — they are overwritten internally from the `*_metric_coefs` parameters, so setting them was silently ineffective.
- Share the `DEPRECATED_OVERLAP_FIELDS` list with the CLI so these options do not appear in `laptrack overlap_track --help`.

Closes #566. Merge after the #528 CLI PR.

## Testing
- New deprecation tests in `tests/test_overlap_tracking.py`; CLI tests confirm the options are absent
- `uv run mypy src` → clean; pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
