### PR TITLE
Add GPU (CuPy) linking computation and ASV benchmarks (#582)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/examples/bright_spots_data/brownian_particles_images.npy
 docs/examples/bright_spots_data/brownian_particles.gif
 docs/examples/bright_spots_data/brownian_particles.npy
 docs/examples/cell_segmentation_data/data.npz
+.asv/

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "project": "laptrack",
+  "project_url": "https://github.com/yfukai/laptrack",
+  "repo": ".",
+  "branches": ["main"],
+  "show_commit_url": "https://github.com/yfukai/laptrack/commit/",
+  "environment_type": "virtualenv",
+  "benchmark_dir": "benchmarks",
+  "env_dir": ".asv/env",
+  "results_dir": ".asv/results",
+  "html_dir": ".asv/html"
+}

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""ASV benchmarks for laptrack."""

--- a/benchmarks/benchmark_linking.py
+++ b/benchmarks/benchmark_linking.py
@@ -1,0 +1,60 @@
+"""ASV benchmarks for the frame-to-frame linking."""
+
+import numpy as np
+
+from laptrack import LapTrack
+
+
+class LinkingSuite:
+    """Benchmark the linking step for the different computation modes."""
+
+    timeout = 600
+    params = ([300, 3000, 10000], ["baseline", "kdtree", "gpu"])
+    param_names = ["n_points", "mode"]
+
+    def setup(self, n_points, mode):
+        """Prepare the coordinates and the tracker."""
+        rng = np.random.RandomState(0)
+        self.coords = [rng.random((n_points, 2)) * 1000 for _ in range(5)]
+        kwargs = dict(
+            cutoff=15.0**2,
+            gap_closing_cutoff=False,
+            splitting_cutoff=False,
+            merging_cutoff=False,
+        )
+        if mode == "kdtree":
+            kwargs["metric_is_distance"] = True
+        elif mode == "gpu":
+            try:
+                import cupy  # noqa: F401
+            except ImportError:
+                raise NotImplementedError("cupy is not installed")
+            kwargs["use_gpu"] = True
+        self.lt = LapTrack(**kwargs)
+
+    def time_predict(self, n_points, mode):
+        """Time the prediction."""
+        self.lt.predict(self.coords)
+
+
+class GapSplitMergeSuite:
+    """Benchmark the tracking with gap closing, splitting and merging."""
+
+    timeout = 600
+    params = [300, 1000]
+    param_names = ["n_points"]
+
+    def setup(self, n_points):
+        """Prepare the coordinates and the tracker."""
+        rng = np.random.RandomState(0)
+        self.coords = [rng.random((n_points, 2)) * 1000 for _ in range(5)]
+        self.lt = LapTrack(
+            cutoff=15.0**2,
+            gap_closing_cutoff=15.0**2,
+            splitting_cutoff=15.0**2,
+            merging_cutoff=15.0**2,
+        )
+
+    def time_predict(self, n_points):
+        """Time the prediction."""
+        self.lt.predict(self.coords)

--- a/src/laptrack/_tracking.py
+++ b/src/laptrack/_tracking.py
@@ -98,6 +98,57 @@ def _get_segment_df(coords, track_tree):
     return segments_df
 
 
+def _gpu_linking_candidates(
+    coord1: np.ndarray,
+    coord2: np.ndarray,
+    metric: Union[str, Callable],
+    cutoff: float,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute the linking candidate pairs within the cutoff on the GPU.
+
+    Parameters
+    ----------
+    coord1 : np.ndarray
+        The coordinates of the first frame.
+    coord2 : np.ndarray
+        The coordinates of the second frame.
+    metric : Union[str, Callable]
+        The metric. Must be "euclidean" or "sqeuclidean".
+    cutoff : float
+        The cutoff for the metric values.
+
+    Returns
+    -------
+    rows : np.ndarray
+        The indices in `coord1` of the candidate pairs.
+    cols : np.ndarray
+        The indices in `coord2` of the candidate pairs.
+    data : np.ndarray
+        The metric values of the candidate pairs.
+    """
+    if metric not in ("euclidean", "sqeuclidean"):
+        raise ValueError(
+            'The GPU computation only supports the "euclidean" and '
+            f'"sqeuclidean" metrics, but got {metric}.'
+        )
+    try:
+        import cupy as cp
+    except ImportError:
+        raise ImportError("Please install `cupy` to use `use_gpu=True`.")
+    c1 = cp.asarray(coord1, dtype=cp.float64)
+    c2 = cp.asarray(coord2, dtype=cp.float64)
+    sq_dist = cp.maximum(
+        cp.sum(c1**2, axis=1)[:, None]
+        + cp.sum(c2**2, axis=1)[None, :]
+        - 2.0 * (c1 @ c2.T),
+        0.0,
+    )
+    dist_matrix = sq_dist if metric == "sqeuclidean" else cp.sqrt(sq_dist)
+    rows, cols = cp.where(dist_matrix < cutoff)
+    data = dist_matrix[rows, cols]
+    return cp.asnumpy(rows), cp.asnumpy(cols), cp.asnumpy(data)
+
+
 _ALIAS_FIELDS = {
     "track_dist_metric": "metric",
     "track_cost_cutoff": "cutoff",
@@ -161,6 +212,16 @@ class LapTrack(BaseModel, extra="forbid"):
         + "If False, no merging is allowed.",
     )
 
+    use_gpu: bool = Field(
+        default=False,
+        description="If True, compute the frame-to-frame linking distance "
+        + "matrix on the GPU with CuPy. Requires `cupy` to be installed and "
+        + 'the metric to be "euclidean" or "sqeuclidean". '
+        + "Takes precedence over `metric_is_distance` in the linking step. "
+        + "The results can differ from the CPU computation within the "
+        + "floating-point rounding error.",
+        exclude=True,
+    )
     metric_is_distance: bool = Field(
         default=False,
         description="If True, the neighbor candidates in the frame-to-frame "
@@ -330,8 +391,13 @@ class LapTrack(BaseModel, extra="forbid"):
 
             force_end_indices = [e[0][1] for e in edges_list if e[0][0] == frame]
             force_start_indices = [e[1][1] for e in edges_list if e[1][0] == frame + 1]
-            if self.metric_is_distance:
-                rows, cols, data = self._get_neighbor_pairs(coord1, coord2)
+            if self.use_gpu or self.metric_is_distance:
+                if self.use_gpu:
+                    rows, cols, data = _gpu_linking_candidates(
+                        coord1, coord2, self.metric, self.cutoff
+                    )
+                else:
+                    rows, cols, data = self._get_neighbor_pairs(coord1, coord2)
                 mask = (
                     ~np.isin(rows, force_end_indices)
                     & ~np.isin(cols, force_start_indices)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -237,6 +237,52 @@ def test_metric_is_distance_with_empty_frames() -> None:
     assert set(lt.predict(coords).edges) == set(lt2.predict(coords).edges)
 
 
+def test_use_gpu_requires_supported_metric() -> None:
+    coords = [np.array([[10, 10], [12, 11]]), np.array([[10, 10], [13, 11]])]
+    lt = LapTrack(
+        use_gpu=True,
+        metric="cityblock",
+        gap_closing_cutoff=False,
+        splitting_cutoff=False,
+        merging_cutoff=False,
+    )
+    with pytest.raises(ValueError, match="GPU computation only supports"):
+        lt.predict(coords)
+
+
+def test_use_gpu_requires_cupy() -> None:
+    try:
+        import cupy  # noqa: F401
+
+        pytest.skip("cupy is installed")
+    except ImportError:
+        pass
+    coords = [np.array([[10, 10], [12, 11]]), np.array([[10, 10], [13, 11]])]
+    lt = LapTrack(
+        use_gpu=True,
+        gap_closing_cutoff=False,
+        splitting_cutoff=False,
+        merging_cutoff=False,
+    )
+    with pytest.raises(ImportError, match="cupy"):
+        lt.predict(coords)
+
+
+def test_use_gpu_equivalence() -> None:
+    pytest.importorskip("cupy")
+    np.random.seed(1)
+    coords = [np.random.random((40, 2)) * 100 for _ in range(5)]
+    params = dict(
+        cutoff=15.0**2,
+        gap_closing_cutoff=False,
+        splitting_cutoff=False,
+        merging_cutoff=False,
+    )
+    tree1 = LapTrack(**params).predict(coords)
+    tree2 = LapTrack(**params, use_gpu=True).predict(coords)
+    assert set(tree1.edges) == set(tree2.edges)
+
+
 def test_tracking_zero_distance() -> None:
     coords = [np.array([[10, 10], [12, 11]]), np.array([[10, 10], [13, 11]])]
     lt = LapTrack(


### PR DESCRIPTION
## Summary
**Draft — the CuPy path needs validation on a GPU machine (this environment has no GPU).**

Stacked on the #538 branch (merge that PR first), per the issue note that this should be done after #538.

- Add a `use_gpu` option to `LapTrack`: the frame-to-frame linking distance matrix is computed on the GPU with CuPy (matmul-based squared distances) for the `euclidean`/`sqeuclidean` metrics, then thresholded on-device and transferred back as sparse candidates.
- Clear errors: `ValueError` for unsupported metrics (checked before the cupy import), `ImportError` when cupy is missing.
- Add an ASV benchmark suite (`asv.conf.json` + `benchmarks/`) comparing the baseline, KD-tree (`metric_is_distance`) and GPU linking modes, plus a gap/split/merge suite; the GPU case raises `NotImplementedError` in `setup` (= skipped by ASV) when cupy is unavailable. Run with `pipx run asv run` (or `uvx asv run`).

TODO before undrafting:
- [ ] Run the equivalence test (`test_use_gpu_equivalence`, currently skipped without cupy) and the ASV suite on a GPU machine
- [ ] Decide whether to extend the GPU path to gap-closing / split / merge candidate searches

Closes #582

## Testing
- CPU-side tests pass: unsupported-metric error, missing-cupy error; full suite 79 passed
- `uv run mypy src` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
